### PR TITLE
Add objects to viewport scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,29 +57,31 @@
     <div id="MainContent" class="flex-grow-1 d-flex flex-row border m-0">
       <div id="SceneTree" class="flex-grow-1 flex-shrink-1 border m-1" style="flex-basis: 20%;">
         <!-- Button trigger modal -->
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addObjectModal">
+        <!-- This cunt's width changes with the parent, don't fucking know why -->
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#AddObjectModal">
           <i class="bi bi-plus"></i>
         </button>
 
         <!-- Modal -->
-        <div class="modal fade" id="addObjectModal" tabindex="-1" aria-labelledby="addObjectModalLabel" aria-hidden="true">
+        <!-- This shit doesn't close after adding the object -->
+        <div id="AddObjectModal" class="modal fade" tabindex="-1" aria-labelledby="AddObjectModalLabel" aria-hidden="true">
           <div class="modal-dialog model-dialog-scrollable">
             <div class="modal-content">
               <div class="modal-header">
-                <h5 class="modal-title" id="addObjectModalLabel">Add object</h5>
+                <h5 id="AddObjectModalLabel" class="modal-title">Add object</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
               </div>
               <div class="modal-body">
                 <div class="list-group">
+                  <a href="#" class="list-group-item list-group-item-action" object-name="Cube">Box</a>
                   <a href="#" class="list-group-item list-group-item-action" object-name="Sphere">Sphere</a>
-                  <a href="#" class="list-group-item list-group-item-action" object-name="Box">Box</a>
                   <a href="#" class="list-group-item list-group-item-action" object-name="Plane">Plane</a>
                   <!-- Add more items here -->
                 </div>
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-primary" id="AddObject">Add</button>
+                <button id="AddObject" type="button" class="btn btn-primary">Add</button>
               </div>
             </div>
           </div>

--- a/js/editor/viewport.js
+++ b/js/editor/viewport.js
@@ -31,7 +31,7 @@ class Viewport {
     );
     this.editor.eventDispatcher.addEventListener(
       this.editor.events.objectAdded.type,
-      this.render.bind(this)
+      this.onObjectAdded.bind(this)
     );
 
     this.controls.addEventListener(
@@ -104,6 +104,12 @@ class Viewport {
   }
 
   // Methods
+  
+  addObject(object) {
+    this.scene.add(object.mesh);
+
+    this.editor.eventDispatcher.dispatchEvent(this.editor.events.objectAdded);
+  }
 
   updateAspectRatio() {
     this.currentCamera.aspect = this.container.clientWidth / this.container.clientHeight;
@@ -121,6 +127,14 @@ class Viewport {
     this.renderer.autoClear = false;
     this.renderer.render(this.grid, this.currentCamera);
     this.renderer.autoClear = true;
+  }
+
+  // Events handlers
+  
+  onObjectAdded() {
+    this.render();
+
+    console.log("Object added successfully");
   }
 }
 

--- a/js/editor/viewport.js
+++ b/js/editor/viewport.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 
 class Viewport {
   constructor(editor) {
@@ -12,16 +13,10 @@ class Viewport {
     // Default camera: perspective
     this.currentCamera = this.perspectiveCamera;
 
-    // try adding object to scene
-    // const geometry = new THREE.BoxGeometry(1, 1, 1);
-    // const material = new THREE.MeshBasicMaterial({
-    //   color: 0x00ff00,
-    // });
-    // const cube = new THREE.Mesh( geometry, material );
+    this.controls = new OrbitControls(this.currentCamera, this.renderer.domElement);
 
     this.scene = new THREE.Scene();
     this.sceneHelper = new THREE.Scene();
-    // this.scene.add(cube);
     this.grid = this.createGrid();
 
     //
@@ -29,15 +24,20 @@ class Viewport {
     this.editor.eventDispatcher.addEventListener(
       this.editor.events.rendererCreated.type,
       this.render.bind(this)
-    )
+    );
     this.editor.eventDispatcher.addEventListener(
       this.editor.events.windowResized.type,
       this.render.bind(this)
-    )
+    );
     this.editor.eventDispatcher.addEventListener(
       this.editor.events.objectAdded.type,
       this.render.bind(this)
-    )
+    );
+
+    this.controls.addEventListener(
+      "change",
+      this.render.bind(this)
+    );
   }
 
   // Initializers

--- a/js/main.js
+++ b/js/main.js
@@ -17,6 +17,11 @@ levelViewport.appendChild(viewport.container);
 // TODO: put this in viewport (viewport.controls for example)
 // zooming in and out is very laggy
 const controls = new OrbitControls(viewport.currentCamera, viewport.renderer.domElement);
+controls.update(); // the update method itself triggers the "change" event
+
+controls.addEventListener("change", function() {
+  viewport.render();
+});
 
 // Temporary solution
 // TODO: create the renderer in editor.js and pass the renderer through a 
@@ -50,16 +55,9 @@ document.getElementById('AddObject').addEventListener('click', function() {
         break;
       case 'Box':
         break;
+      case 'Plane':
+        break;
     }
   }
 });
 
-// without this zooming in and out is fucking laggy, don't know why
-function animate() {
-  requestAnimationFrame(animate);
-
-  controls.update();
-  viewport.render();
-}
-
-animate();

--- a/js/main.js
+++ b/js/main.js
@@ -2,7 +2,9 @@ import { Editor } from "./editor/editor.js";
 import { VerticalResizer } from "./editor/vertical-resizer.js";
 import { Viewport } from "./editor/viewport.js";
 
-import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { Cube } from "./threejs/objects/cube.js";
+import { Plane } from "./threejs/objects/plane.js";
+import { Sphere } from "./threejs/objects/sphere.js";
 
 const editor = new Editor();
 
@@ -38,15 +40,24 @@ document.querySelectorAll('.list-group-item').forEach(function(item) {
 // add click event listener to "Add" button in the popup modal
 document.getElementById('AddObject').addEventListener('click', function() {
   const activeItems = document.getElementsByClassName('active');
+
   if (activeItems.length > 0) {
     const selectedObject = activeItems[0].getAttribute('object-name');
+
     console.log('Adding object: ' + selectedObject);
+
     switch (selectedObject) {
-      case 'Sphere':
+      case 'Cube':
+        viewport.addObject(new Cube());
+
         break;
-      case 'Box':
+      case 'Sphere':
+        viewport.addObject(new Sphere());
+
         break;
       case 'Plane':
+        viewport.addObject(new Plane());
+
         break;
     }
   }

--- a/js/main.js
+++ b/js/main.js
@@ -14,15 +14,6 @@ const levelViewport = document.getElementById("LevelViewport");
 const viewport = new Viewport(editor);
 levelViewport.appendChild(viewport.container);
 
-// TODO: put this in viewport (viewport.controls for example)
-// zooming in and out is very laggy
-const controls = new OrbitControls(viewport.currentCamera, viewport.renderer.domElement);
-controls.update(); // the update method itself triggers the "change" event
-
-controls.addEventListener("change", function() {
-  viewport.render();
-});
-
 // Temporary solution
 // TODO: create the renderer in editor.js and pass the renderer through a 
 // custom event

--- a/js/threejs/objects/cube.js
+++ b/js/threejs/objects/cube.js
@@ -1,0 +1,13 @@
+import * as THREE from "three";
+
+class Cube {
+  constructor() {
+    this.geometry = new THREE.BoxGeometry(1, 1, 1);
+    this.material = new THREE.MeshBasicMaterial({
+      color: 0x808080
+    });
+    this.mesh = new THREE.Mesh(this.geometry, this.material);
+  }
+}
+
+export { Cube };

--- a/js/threejs/objects/plane.js
+++ b/js/threejs/objects/plane.js
@@ -1,0 +1,11 @@
+import * as THREE from "three";
+
+class Plane {
+  constructor() {
+    this.geometry = new THREE.PlaneGeometry(2, 2);
+    this.material = new THREE.MeshBasicMaterial({ color: 0x808080 });
+    this.mesh = new THREE.Mesh(this.geometry, this.material);
+  }
+}
+
+export { Plane };

--- a/js/threejs/objects/sphere.js
+++ b/js/threejs/objects/sphere.js
@@ -1,0 +1,11 @@
+import * as THREE from "three";
+
+class Sphere {
+  constructor() {
+    this.geometry = new THREE.SphereGeometry(1, 32, 32);
+    this.material = new THREE.MeshBasicMaterial({ color: 0x808080 });
+    this.mesh = new THREE.Mesh(this.geometry, this.material);
+  }
+}
+
+export { Sphere };


### PR DESCRIPTION
Changes:
- Create wrapper classes for Three.js objects: Cube, Sphere, and Plane
- Move orbit controls inside `viewport.js`, and fix the update issue (don't need to use `requestAnimationFrame` anymore)
- Can now add the objects to viewport scene via AddObjectModal

Still not fixed:
- After adding an object, the modal doesn't automatically close