### PR TITLE
Enhance undo and redo logic

### DIFF
--- a/js/editor/editor.js
+++ b/js/editor/editor.js
@@ -1,4 +1,6 @@
 import * as THREE from "three";
+import { History } from "./history.js";
+import { Selector } from "./selector.js";
 
 class Editor {
   constructor() {
@@ -21,9 +23,14 @@ class Editor {
       transformModeChanged: new Event( "transformModeChanged" ),
     };
 
-    this.history = null;
+    this.history = new History( this );
+    this.selector = new Selector( this );
 
     this.scene = new THREE.Scene();
+    this.scene.name = "Scene";
+
+    this.sceneHelper = new THREE.Scene();
+    this.sceneHelper.add( new THREE.HemisphereLight( 0xffffff, 0x888888, 2 ) );
   }
 }
 

--- a/js/editor/history.js
+++ b/js/editor/history.js
@@ -4,9 +4,6 @@ class History {
     this.eventDispatcher = editor.eventDispatcher;
     this.events = editor.events;
 
-    this.viewport = null;
-    this.scene = editor.scene;
-
     this.maxEntries = 100;
     this.undos = [];
     this.redos = [];
@@ -43,7 +40,7 @@ class History {
 
     switch ( entry.type ) {
       case "add":
-        this.scene.remove( entry.object );
+        this.editor.scene.remove( entry.object );
 
         this.dispatchObjectRemovedEvent( null );
 
@@ -51,7 +48,7 @@ class History {
 
         break;
       case "remove":
-        this.scene.add( entry.object );
+        this.editor.scene.add( entry.object );
 
         this.dispatchObjectAddedEvent( null );
 
@@ -59,7 +56,7 @@ class History {
 
         break;
       case "change":
-        let object = this.scene.getObjectById( entry.id );
+        let object = this.editor.scene.getObjectById( entry.id );
 
         // The top entry in undos only contains the last action, therefore we need
         // to push the current object state to redos before undoing
@@ -90,7 +87,7 @@ class History {
 
     switch ( entry.type ) {
       case "add":
-        this.scene.add( entry.object );
+        this.editor.scene.add( entry.object );
 
         this.dispatchObjectAddedEvent( null );
 
@@ -98,7 +95,7 @@ class History {
 
         break;
       case "remove":
-        this.scene.remove( entry.object );
+        this.editor.scene.remove( entry.object );
 
         this.dispatchObjectRemovedEvent( null );
 
@@ -106,7 +103,7 @@ class History {
 
         break;
       case "change":
-        let object = this.scene.getObjectById( entry.id );
+        let object = this.editor.scene.getObjectById( entry.id );
 
         // Same logic as in unfo(), we need to push current object state t
         // undos before redoing
@@ -200,7 +197,6 @@ class History {
     }
 
     const lastEntry = this.undos[ this.undos.length - 1 ];
-    console.log(lastEntry);
     if (!lastEntry) {
       this.undos.push( entry );
     } else if (JSON.stringify( entry ) !== JSON.stringify( lastEntry )) {

--- a/js/editor/history.js
+++ b/js/editor/history.js
@@ -45,7 +45,7 @@ class History {
       case "add":
         this.scene.remove( entry.object );
 
-        this.viewport.render();
+        this.dispatchObjectRemovedEvent( null );
 
         this.redos.push( entry );
 
@@ -53,7 +53,7 @@ class History {
       case "remove":
         this.scene.add( entry.object );
 
-        this.viewport.render();
+        this.dispatchObjectAddedEvent( null );
 
         this.redos.push( entry );
 
@@ -92,7 +92,7 @@ class History {
       case "add":
         this.scene.add( entry.object );
 
-        this.viewport.render();
+        this.dispatchObjectAddedEvent( null );
 
         this.undos.push( entry );
 
@@ -100,7 +100,7 @@ class History {
       case "remove":
         this.scene.remove( entry.object );
 
-        this.viewport.render();
+        this.dispatchObjectRemovedEvent( null );
 
         this.undos.push( entry );
 
@@ -133,9 +133,9 @@ class History {
   // Event handlers
 
   onObjectAdded( event ) {
-    const object = event.detail.object;
+    if (!event.detail.object) { return; }
 
-    if (!object) { return; }
+    const object = event.detail.object;
 
     if (this.newUndoBranch) {
       this.redos.splice( 0, this.redos.length );
@@ -155,9 +155,9 @@ class History {
   }
 
   onObjectRemoved( event ) {
-    const object = event.detail.object;
+    if (!event.detail.object) { return; }
 
-    if (!object) { return; }
+    const object = event.detail.object;
 
     if (this.newUndoBranch) {
       this.redos.splice( 0, this.redos.length );
@@ -178,10 +178,9 @@ class History {
 
   onObjectChanged( event ) {
     if (!this.recordChange) { return; }
+    if (!event.detail.object) { return; }
 
     const object = event.detail.object;
-
-    if (!object) { return; }
 
     if (this.newUndoBranch) {
       this.redos.splice( 0, this.redos.length );
@@ -212,6 +211,28 @@ class History {
   }
 
   // Dispatch custom events
+
+  dispatchObjectAddedEvent( object ) {
+    this.eventDispatcher.dispatchEvent(new CustomEvent(
+      this.events.objectAdded.type,
+      {
+        detail: {
+          object: object
+        }
+      }
+    ));
+  }
+
+  dispatchObjectRemovedEvent( object ) {
+    this.eventDispatcher.dispatchEvent(new CustomEvent(
+      this.events.objectRemoved.type,
+      {
+        detail: {
+          object: object
+        }
+      }
+    ));
+  }
 
   dispatchObjectChangedEvent( object ) {
     this.eventDispatcher.dispatchEvent(new CustomEvent(

--- a/js/editor/properties.js
+++ b/js/editor/properties.js
@@ -38,8 +38,9 @@ class ReadOnlyProperty {
 }
 
 class ValueSliderProperty {
-  constructor( parent, propertyLabel, value, min, max, step ) {
-    this.history = null;
+  constructor( editor, parent, propertyLabel, value, min, max, step ) {
+    this.editor = editor;
+    this.history = editor.history;
 
     this.parent = parent;
 
@@ -116,7 +117,10 @@ class ValueSliderProperty {
 }
 
 class BooleanProperty {
-  constructor(parent, propertyLabel, value) {
+  constructor( editor, parent, propertyLabel, value ) {
+    this.editor = editor;
+    this.history = editor.history;
+
     this.parent = parent;
 
     this.listItem = document.createElement("div");
@@ -159,7 +163,10 @@ class BooleanProperty {
 }
 
 class DropdownProperty {
-  constructor(parent, propertyLabel, options, selectedOption) {
+  constructor( editor, parent, propertyLabel, options, selectedOption ) {
+    this.editor = editor;
+    this.history = editor.history;
+
     this.parent = parent;
 
     this.listItem = document.createElement("div");
@@ -206,9 +213,11 @@ class DropdownProperty {
 
 
 class Vector3Property {
-  constructor(object, parent, propertyLabel, vector3, type) {
-    this.editor = null;
-    this.history = null;
+  constructor( editor, object, parent, propertyLabel, vector3, type ) {
+    this.editor = editor;
+    this.history = editor.history;
+    this.eventDispatcher = editor.eventDispatcher;
+    this.events = editor.events;
 
     this.object = object;
     this.parent = parent;
@@ -322,21 +331,11 @@ class Vector3Property {
     )
     this.inputNumberX.addEventListener(
       "focus",
-      ( event ) => {
-        this.history.recordChange = true;
-        this.history.newUndoBranch = true;
-
-        this.dispatchObjectChangedEvent( this.object );
-
-        this.history.recordChange = true;
-      }
+      this.onFocus.bind( this )
     )
-
     this.inputNumberX.addEventListener(
       "blur",
-      ( event ) => {
-        this.history.recordChange = false;
-      }
+      this.onBlur.bind( this )
     )
 
     this.inputNumberY.addEventListener(
@@ -356,24 +355,13 @@ class Vector3Property {
         this.dispatchObjectChangedEvent( this.object );
       }
     )
-
     this.inputNumberY.addEventListener(
       "focus",
-      ( event ) => {
-        this.history.recordChange = true;
-        this.history.newUndoBranch = true;
-
-        this.dispatchObjectChangedEvent( this.object );
-
-        this.history.recordChange = true;
-      }
+      this.onFocus.bind( this )
     )
-
     this.inputNumberY.addEventListener(
       "blur",
-      ( event ) => {
-        this.history.recordChange = false;
-      }
+      this.onBlur.bind( this )
     )
 
     this.inputNumberZ.addEventListener(
@@ -394,30 +382,34 @@ class Vector3Property {
 
       }
     )
-
     this.inputNumberZ.addEventListener(
       "focus",
-      ( event ) => {
-        this.history.recordChange = true;
-        this.history.newUndoBranch = true;
-
-        this.dispatchObjectChangedEvent( this.object );
-
-        this.history.recordChange = true;
-      }
+      this.onFocus.bind( this )
     )
-
     this.inputNumberZ.addEventListener(
       "blur",
-      ( event ) => {
-        this.history.recordChange = false;
-      }
+      this.onBlur.bind( this )
     )
   }
 
+  // Event handlers
+  
+  onFocus() {
+    this.history.recordChange = true;
+    this.history.newUndoBranch = true;
+
+    this.dispatchObjectChangedEvent( this.object );
+  }
+
+  onBlur() {
+    this.history.recordChange = false;
+  }
+
+  // Dispatch custome events
+
   dispatchObjectChangedEvent( object ) {
-    this.editor.eventDispatcher.dispatchEvent(new CustomEvent(
-      this.editor.events.objectChanged.type,
+    this.eventDispatcher.dispatchEvent(new CustomEvent(
+      this.events.objectChanged.type,
       {
         detail: {
           object: object,
@@ -428,9 +420,11 @@ class Vector3Property {
 }
 
 class EulerProperty {
-  constructor(object, parent, propertyLabel, euler) {
-    this.editor = null;
-    this.history = null;
+  constructor( editor, object, parent, propertyLabel, euler ) {
+    this.editor = editor;
+    this.history = editor.history;
+    this.eventDispatcher = editor.eventDispatcher;
+    this.events = editor.events;
 
     this.object = object;
     this.parent = parent;
@@ -535,19 +529,11 @@ class EulerProperty {
     )
     this.inputNumberX.addEventListener(
       "focus",
-      (event) => {
-        this.history.recordChange = true;
-        this.history.newUndoBranch = true;
-
-        this.dispatchObjectChangedEvent( this.object );
-        this.history.recordChange = true;
-      }
+      this.onFocus.bind( this )
     )
     this.inputNumberX.addEventListener(
       "blur",
-      (event) => {
-        this.history.recordChange = false;
-      }
+      this.onBlur.bind( this )
     )
 
     this.inputNumberY.addEventListener(
@@ -562,19 +548,11 @@ class EulerProperty {
     )
     this.inputNumberY.addEventListener(
       "focus",
-      (event) => {
-        this.history.recordChange = true;
-        this.history.newUndoBranch = true;
-
-        this.dispatchObjectChangedEvent( this.object );
-        this.history.recordChange = true;
-      }
+      this.onFocus.bind( this )
     )
     this.inputNumberY.addEventListener(
       "blur",
-      (event) => {
-        this.history.recordChange = false;
-      }
+      this.onBlur.bind( this )
     )
 
     this.inputNumberZ.addEventListener(
@@ -589,25 +567,32 @@ class EulerProperty {
     )
     this.inputNumberZ.addEventListener(
       "focus",
-      (event) => {
-        this.history.recordChange = true;
-        this.history.newUndoBranch = true;
-
-        this.dispatchObjectChangedEvent( this.object );
-        this.history.recordChange = true;
-      }
+      this.onFocus.bind( this )
     )
     this.inputNumberZ.addEventListener(
       "blur",
-      (event) => {
-        this.history.recordChange = false;
-      }
+      this.onBlur.bind( this )
     )
   }
 
+  // Event handlers
+
+  onFocus() {
+    this.history.recordChange = true;
+    this.history.newUndoBranch = true;
+
+    this.dispatchObjectChangedEvent( this.object );
+  }
+
+  onBlur() {
+    this.history.recordChange = false;
+  }
+
+  // Dispatch custom events
+
   dispatchObjectChangedEvent( object ) {
-    this.editor.eventDispatcher.dispatchEvent(new CustomEvent(
-      this.editor.events.objectChanged.type,
+    this.eventDispatcher.dispatchEvent(new CustomEvent(
+      this.events.objectChanged.type,
       {
         detail: {
           object: object,
@@ -706,17 +691,9 @@ class MeshProperties extends Properties {
     this.objectUuid = new ReadOnlyProperty( this.objectProperties, "UUID", this.mesh.uuid, "text" );
     this.objectType = new ReadOnlyProperty( this.objectProperties, "Type", this.mesh.type, "text" );
 
-    this.objectPosition = new Vector3Property( this.mesh, this.objectProperties, "Position", this.mesh.position, "position" );
-    this.objectPosition.editor = this.editor;
-    this.objectPosition.history = this.editor.history;
-
-    this.objectRotation = new EulerProperty( this.mesh, this.objectProperties, "Rotation", this.mesh.rotation );
-    this.objectRotation.editor = this.editor;
-    this.objectRotation.history = this.editor.history;
-
-    this.objectScale = new Vector3Property( this.mesh, this.objectProperties, "Scale", this.mesh.scale, "scale" );
-    this.objectScale.editor = this.editor;
-    this.objectScale.history = this.editor.history;
+    this.objectPosition = new Vector3Property( this.editor, this.mesh, this.objectProperties, "Position", this.mesh.position, "position" );
+    this.objectRotation = new EulerProperty( this.editor, this.mesh, this.objectProperties, "Rotation", this.mesh.rotation );
+    this.objectScale = new Vector3Property( this.editor, this.mesh, this.objectProperties, "Scale", this.mesh.scale, "scale" );
 
     this.geometryProperties = this.createListGroup( "Geometry" );
     this.geometryType = new ReadOnlyProperty( this.geometryProperties, "Type", this.mesh.geometry.type, "text");
@@ -724,31 +701,31 @@ class MeshProperties extends Properties {
       case "BoxGeometry":
         var params = this.mesh.geometry.parameters;
 
-        this.boxGeometryWidth = new ValueSliderProperty( this.geometryProperties, "Width", params.width, 1, 30, 0.001 );
-        this.boxGeometryHeight = new ValueSliderProperty( this.geometryProperties, "Height", params.height, 1, 30, 0.001 );
-        this.boxGeometryDepth = new ValueSliderProperty( this.geometryProperties, "Depth", params.depth, 1, 30, 0.001 );
-        this.boxGeometryWidthSegments = new ValueSliderProperty( this.geometryProperties, "Width Segments", params.widthSegments, 1, 10, 1 );
-        this.boxGeometryHeightSegments = new ValueSliderProperty( this.geometryProperties, "Height Segments", params.heightSegments, 1, 10, 1 );
-        this.boxGeometryDepthSegments = new ValueSliderProperty( this.geometryProperties, "Depth Segments", params.depthSegments, 1, 10, 1 );
+        this.boxGeometryWidth = new ValueSliderProperty( this.editor, this.geometryProperties, "Width", params.width, 1, 30, 0.001 );
+        this.boxGeometryHeight = new ValueSliderProperty( this.editor, this.geometryProperties, "Height", params.height, 1, 30, 0.001 );
+        this.boxGeometryDepth = new ValueSliderProperty( this.editor, this.geometryProperties, "Depth", params.depth, 1, 30, 0.001 );
+        this.boxGeometryWidthSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Width Segments", params.widthSegments, 1, 10, 1 );
+        this.boxGeometryHeightSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Height Segments", params.heightSegments, 1, 10, 1 );
+        this.boxGeometryDepthSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Depth Segments", params.depthSegments, 1, 10, 1 );
         // test boolean property
-        this.boxGeometryVisible = new BooleanProperty(this.geometryProperties, "Visible", true);
+        this.boxGeometryVisible = new BooleanProperty( this.editor, this.geometryProperties, "Visible", true );
 
         break;
       case "PlaneGeometry":
         var params = this.mesh.geometry.parameters;
 
-        this.planeGeometryWidth = new ValueSliderProperty( this.geometryProperties, "Width", params.width, 1, 30, 0.001 );
-        this.planeGeometryHeight = new ValueSliderProperty( this.geometryProperties, "Height", params.height, 1, 30, 0.001 );
-        this.planeGeometryWidthSegments = new ValueSliderProperty( this.geometryProperties, "Width Segments", params.widthSegments, 1, 30, 1 );
-        this.planeGeometryHeightSegments = new ValueSliderProperty( this.geometryProperties, "Height Segments", params.heightSegments, 1, 30, 1 );
+        this.planeGeometryWidth = new ValueSliderProperty( this.editor, this.geometryProperties, "Width", params.width, 1, 30, 0.001 );
+        this.planeGeometryHeight = new ValueSliderProperty( this.editor, this.geometryProperties, "Height", params.height, 1, 30, 0.001 );
+        this.planeGeometryWidthSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Width Segments", params.widthSegments, 1, 30, 1 );
+        this.planeGeometryHeightSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Height Segments", params.heightSegments, 1, 30, 1 );
 
         break;
       case "SphereGeometry":
         var params = this.mesh.geometry.parameters;
         
-        this.sphereRadius = new ValueSliderProperty( this.geometryProperties, "Radius", params.radius, 1, 30, 0.001 );
-        this.sphereWidthSegments = new ValueSliderProperty( this.geometryProperties, "Width Segments", params.widthSegments, 1, 64, 1 );
-        this.sphereHeightSegments = new ValueSliderProperty( this.geometryProperties, "Height Segments", params.heightSegments, 1, 32, 1 );
+        this.sphereRadius = new ValueSliderProperty( this.editor, this.geometryProperties, "Radius", params.radius, 1, 30, 0.001 );
+        this.sphereWidthSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Width Segments", params.widthSegments, 1, 64, 1 );
+        this.sphereHeightSegments = new ValueSliderProperty( this.editor, this.geometryProperties, "Height Segments", params.heightSegments, 1, 32, 1 );
 
         break;
     }
@@ -756,7 +733,9 @@ class MeshProperties extends Properties {
     this.materialProperties = this.createListGroup( "Material" );
     // test dropdown property
     console.log(this.mesh.material.type);
-    this.materialType = new DropdownProperty(this.materialProperties, "Type", ["MeshPhongMaterial", "MeshStandardMaterial", "MeshBasicMaterial", "MeshNormalMaterial"], this.mesh.material.type);
+    this.materialType = new DropdownProperty( this.editor, this.materialProperties, "Type",
+      ["MeshPhongMaterial", "MeshStandardMaterial", "MeshBasicMaterial", "MeshNormalMaterial"],
+      this.mesh.material.type);
 
     this.textureProperties = this.createListGroup( "Texture" );
 

--- a/js/editor/selector.js
+++ b/js/editor/selector.js
@@ -4,10 +4,10 @@ const mouse = new THREE.Vector2();
 const raycaster = new THREE.Raycaster();
 
 class Selector {
-  constructor( viewport ) {
-    this.viewport = viewport;
-    this.eventDispatcher = this.viewport.eventDispatcher;
-    this.events = this.viewport.events;
+  constructor( editor ) {
+    this.editor = editor;
+    this.eventDispatcher = editor.eventDispatcher;
+    this.events = editor.events;
 
     this.ignore = false;
 
@@ -28,7 +28,7 @@ class Selector {
   getIntersects( raycaster ) {
     const objects = [];
 
-    this.viewport.scene.traverseVisible( function( child ) {
+    this.editor.scene.traverseVisible( function( child ) {
       objects.push( child );
     });
 

--- a/js/editor/selector.js
+++ b/js/editor/selector.js
@@ -56,6 +56,10 @@ class Selector {
     )    
   }
 
+  deselect() {
+    this.select( null );
+  }
+
   // Event handlers
   
   onIntersectionsDetected( event ) {
@@ -67,7 +71,7 @@ class Selector {
       const object = intersects[ 0 ].object;
       this.select( object );
     } else {
-      this.select( null );
+      this.deselect();
     }
   }
 }

--- a/js/editor/viewport.js
+++ b/js/editor/viewport.js
@@ -12,7 +12,7 @@ class Viewport {
     this.events = editor.events;
 
     this.history = editor.history;
-    this.selector = new Selector( this );
+    this.selector = editor.selector;
 
     this.container = this.createContainer();
     this.renderer = this.createRenderer();
@@ -26,12 +26,9 @@ class Viewport {
 
     this.orbitControls = new OrbitControls( this.currentCamera, this.renderer.domElement );
 
-    // this.scene = new THREE.Scene();
-    // this.scene.name = "Scene";
     this.scene = editor.scene;
-    this.scene.name = "Scene";
 
-    this.sceneHelper = new THREE.Scene();
+    this.sceneHelper = editor.sceneHelper;
     this.grid = this.createGrid();
 
     this.transformControls = new TransformControls( this.currentCamera, this.renderer.domElement );
@@ -100,12 +97,13 @@ class Viewport {
         this.dispatchObjectChangedEvent( this.transformControls.object );
       }
     );
-
     this.transformControls.addEventListener(
       "mouseDown",
       ( event ) => {
         this.history.recordChange = true;
         this.history.newUndoBranch = true;
+
+        this.dispatchObjectChangedEvent( this.transformControls.object );
       }
     );
     this.transformControls.addEventListener(

--- a/js/editor/viewport.js
+++ b/js/editor/viewport.js
@@ -125,12 +125,6 @@ class Viewport {
     const transformButtons = [translateButton, rotateButton, scaleButton];
 
     for (let button of transformButtons) {
-      button.addEventListener('mouseenter', () => {
-        this.selector.ignore = true;
-      })
-      button.addEventListener('mouseleave', () => {
-        this.selector.ignore = false;
-      })
       button.onclick = () => {
         for (let button of transformButtons) {
           button.classList.add('btn-secondary');
@@ -301,6 +295,7 @@ class Viewport {
 
   onObjectRemoved( event ) {
     this.transformControls.detach();
+    this.selector.deselect();
 
     this.render();
   }

--- a/js/editor/viewport.js
+++ b/js/editor/viewport.js
@@ -73,7 +73,7 @@ class Viewport {
     );
     this.eventDispatcher.addEventListener(
       this.events.objectRemoved.type,
-      this.render.bind( this )
+      this.onObjectRemoved.bind( this )
     );
 
     this.orbitControls.addEventListener(
@@ -152,6 +152,20 @@ class Viewport {
     this.eventDispatcher.addEventListener(
       this.events.transformModeChanged.type,
       this.onTransformModeChanged.bind(this)
+    )
+
+    // Make selector only work in viewport
+    this.container.addEventListener(
+      "mouseenter",
+      ( event ) => {
+        this.selector.ignore = false;
+      }
+    )
+    this.container.addEventListener(
+      "mouseleave",
+      ( event ) => {
+        this.selector.ignore = true;
+      }
     )
   }
 
@@ -286,6 +300,8 @@ class Viewport {
   }
 
   onObjectRemoved( event ) {
+    this.transformControls.detach();
+
     this.render();
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -101,18 +101,6 @@ editor.eventDispatcher.addEventListener(
     viewport.render();
   }
 );
-rightSideBar.addEventListener(
-  "mouseenter",
-  function( event ) {
-    viewport.selector.ignore = true;
-  }
-);
-rightSideBar.addEventListener(
-  "mouseleave",
-  function( event ) {
-    viewport.selector.ignore = false;
-  }
-);
 
 // add click event listener to each group item
 const addObjectModal = document.getElementById( "AddObjectModal" );

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 import { Editor } from "./editor/editor.js";
-import { History } from "./editor/history.js";
 import { MeshProperties } from "./editor/properties.js";
 import { SceneTree } from "./editor/scene-tree.js";
 import { VerticalResizer } from "./editor/vertical-resizer.js";
@@ -21,13 +20,8 @@ const mainContent = document.getElementById( "MainContent" );
 let availableHeight = window.innerHeight - (menuBar.clientHeight + mainToolBar.clientHeight);
 mainContent.style.height = `${ 100 * availableHeight / window.innerHeight }%`;
 
-// Holy shit, did i just accidentally use dependency injection?
 const editor = new Editor();
-const history = new History( editor );
-editor.history = history;
-
 const viewport = new Viewport( editor );
-history.viewport = viewport;
 
 const leftSideBar = document.getElementById( "LeftSideBar" );
 const levelViewport = document.getElementById( "LevelViewport" );
@@ -67,13 +61,13 @@ const editRedo = document.getElementById( "EditRedo" );
 editUndo.addEventListener(
   "click",
   function( event ) {
-    history.undo();
+    editor.history.undo();
   }
 );
 editRedo.addEventListener(
   "click",
   function( event ) {
-    history.redo();
+    editor.history.redo();
   }
 )
 


### PR DESCRIPTION
On `mouseDown` (`transformControls`) and on `focus` (input), we set `history.recordChange` and `history.newUndoBranch` to true, dispatch the `objectChanged` event, and then set the `history.recordChange` to true again to record the next change once. But this will create a problem: if we add an object and drag it on the x-axis to the right, let's say 3 units, and then perform an undo, but then the position `x` value does not go back to 0 but to something like 0.001xxx...

To fix this, just don't set `history.recordChange` to true again after dispatching the `objectChanged` event.

Also did a bunch of cleaning up.