### PR TITLE
Improve maintainability in `properties.js` and refresh scene tree on object removed

### DIFF
--- a/js/editor/editor.js
+++ b/js/editor/editor.js
@@ -26,12 +26,33 @@ class Editor {
     this.history = new History( this );
     this.selector = new Selector( this );
 
+    this.perspectiveCamera = this.createPerspectiveCamera();
+    this.orthographicCamera = this.createOrthographicCamera();
+    this.camera = this.perspectiveCamera; // Defaults to perspective camera
+
+    this.viewportCamera = this.camera;
+    this.viewportCamera.name = "Viewport Camera";
+
     this.scene = new THREE.Scene();
     this.scene.name = "Scene";
 
     this.sceneHelper = new THREE.Scene();
     this.sceneHelper.add( new THREE.HemisphereLight( 0xffffff, 0x888888, 2 ) );
   }
+
+  createPerspectiveCamera() {
+    const camera = new THREE.PerspectiveCamera( 50, 1, 0.1, 1000 );
+
+    camera.position.set( 0, 5, 10 );
+    camera.lookAt( new THREE.Vector3( 0, 0, 0 ) );
+
+    return camera;
+  }
+
+  createOrthographicCamera() {
+
+  }
+
 }
 
 export { Editor };

--- a/js/editor/scene-tree.js
+++ b/js/editor/scene-tree.js
@@ -130,11 +130,11 @@ class Node {
 }
 
 class SceneTree {
-  constructor( viewport ) {
+  constructor( editor ) {
     // Make use of a data structure for these fucking nodes?
-    this.viewport = viewport;
-    this.eventDispatcher = viewport.eventDispatcher;
-    this.events = viewport.events;
+    this.editor = editor;
+    this.eventDispatcher = editor.eventDispatcher;
+    this.events = editor.events;
 
     this.selectedNode = null; // Don't know what to do with this yet
 
@@ -161,7 +161,7 @@ class SceneTree {
 
     //
 
-    this.refreshNodes();
+    this.refresh();
 
     this.setupEventListeners();
   }
@@ -172,6 +172,11 @@ class SceneTree {
     this.eventDispatcher.addEventListener(
       this.events.objectAdded.type,
       this.onObjectAdded.bind( this )
+    )
+
+    this.eventDispatcher.addEventListener(
+      this.events.objectRemoved.type,
+      this.onObjectRemoved.bind( this )
     )
   }
 
@@ -200,11 +205,11 @@ class SceneTree {
     }
   }
 
-  refreshNodes() {
+  refresh() {
     this.nodes.splice( 0, this.nodes.length );
 
-    const camera = this.viewport.currentCamera;
-    const scene = this.viewport.scene;
+    const camera = this.editor.viewportCamera;
+    const scene = this.editor.scene;
 
     const nodes = [];
 
@@ -241,7 +246,11 @@ class SceneTree {
   // Event handlers
 
   onObjectAdded() {
-    this.refreshNodes();
+    this.refresh();
+  }
+
+  onObjectRemoved() {
+    this.refresh();
   }
 
   onDrag() {

--- a/js/main.js
+++ b/js/main.js
@@ -32,7 +32,7 @@ levelViewport.appendChild( viewport.container );
 const leftVerticalResizer = new VerticalResizer( editor, leftSideBar, levelViewport );
 const rightVerticalResizer = new VerticalResizer( editor, levelViewport, rightSideBar );
 
-const sceneTree = new SceneTree( viewport );
+const sceneTree = new SceneTree( editor );
 leftSideBar.appendChild( sceneTree.container );
 
 


### PR DESCRIPTION
I also moved stuff like `sceneHelper` and all the cameras from `viewport.js` to `editor.js` so we can access them easier and don't have to reference the viewport when we do that.